### PR TITLE
PP-4491: Remove chamber scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM govukpay/nodejs:8.11.3
+FROM govukpay/nodejs:alpine-3.8.1
 
 WORKDIR /app
 
@@ -9,4 +9,4 @@ RUN npm install
 
 ADD . /app
 
-CMD 'tail -f /dev/null'
+CMD ["node", "index.js"]

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env ash
-
-AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" -- node index.js


### PR DESCRIPTION
We no longer use chamber now that ECS supports pulling secrets directly from
parameter store.

Remove the script and change the entrypoint for the container to run the
application directly.

Also, update to our latest alpine 3.8.1 base image, which doesn't include
chamber.